### PR TITLE
Operationalize SSC operations

### DIFF
--- a/init_workflow.py
+++ b/init_workflow.py
@@ -167,7 +167,13 @@ def download_directory(config_bucket, prefix, efs_dir):
         Bucket=config_bucket,
         Prefix=prefix
     )
-    items = [key["Key"] for page in page_iterator for key in page["Contents"]]
+
+    items = []
+    for page in page_iterator:
+        if page.get("Contents", None):
+            for content in page.get("Contents"):
+                items.append(content["Key"])
+
     for item in items:
         efs_file = efs_dir.joinpath(item)
         if not efs_file.exists():
@@ -180,6 +186,9 @@ def download_directory(config_bucket, prefix, efs_dir):
             logging.info("Downloaded %s/%s to %s", config_bucket, item, efs_file)
         else:
             logging.info("Not downloading %s", efs_file)
+
+    if len(items) == 0:
+        logging.info("No items detected for %s/%s", config_bucket, prefix)
 
 
 if __name__ == "__main__":

--- a/init_workflow.py
+++ b/init_workflow.py
@@ -77,6 +77,7 @@ def set_up_efs():
 
     EFS_DIR_INPUT.joinpath("gage").mkdir(parents=True, exist_ok=True)
     EFS_DIR_INPUT.joinpath("gage").joinpath("Rtarget").mkdir(parents=True, exist_ok=True)
+    EFS_DIR_INPUT.joinpath("ssc").mkdir(parents=True, exist_ok=True)
     EFS_DIR_INPUT.joinpath("sos").mkdir(parents=True, exist_ok=True)
     EFS_DIR_INPUT.joinpath("sword").mkdir(parents=True, exist_ok=True)
     EFS_DIR_INPUT.joinpath("swot").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Details

Set up EFS for SSC operations and optionally download static SSC input data; this is not required as we may not always want to run the SSC operations.

# Testing

Deployed to AWS account and tested with SSC operations including the output module